### PR TITLE
Migrate from `moment` to `date-fns`

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "ci": "yarn test && yarn test:e2e"
   },
   "dependencies": {
-    "@date-io/moment": "^1.3.13",
+    "@date-io/date-fns": "^1.3.13",
     "@formatjs/intl-pluralrules": "^1.5.9",
     "@formatjs/intl-relativetimeformat": "^4.5.16",
     "@material-ui/core": "4.10.2",
@@ -34,8 +34,8 @@
     "browser-locale": "^1.0.3",
     "chart.js": "^2.9.3",
     "classnames": "^2.2.6",
+    "date-fns": "^2.16.1",
     "lodash": "^4.17.11",
-    "moment": "^2.22.2",
     "react": "16.13.1",
     "react-app-polyfill": "^1.0.6",
     "react-chartjs-2": "^2.9.0",

--- a/src/components/withProviders.tsx
+++ b/src/components/withProviders.tsx
@@ -1,15 +1,14 @@
-import React, { useEffect, useMemo } from 'react';
+import React, { useMemo } from 'react';
 import { useSelector } from 'react-redux';
 import { BrowserRouter } from 'react-router-dom';
 import { MuiThemeProvider } from '@material-ui/core/styles';
 import { MuiPickersUtilsProvider } from '@material-ui/pickers';
-import MomentUtils from '@date-io/moment';
+import DateFnsAdapter from '@date-io/date-fns';
 import { IntlProvider } from 'react-intl';
-import moment from 'moment';
-import 'moment/locale/de';
 import useMediaQuery from '@material-ui/core/useMediaQuery';
 import { RootState } from '../utils/store';
 import { lightTheme, darkTheme } from '../theme';
+import { getLocale } from '../utils/dateUtils';
 
 const messages = {
   en: require('../locale/en.json'),
@@ -37,17 +36,12 @@ const withProviders = (
       }
     }, [preferedTheme, prefersDarkMode]);
 
-    useEffect(() => {
-      moment.locale(locale);
-    }, [locale]);
-
     return (
       <IntlProvider locale={locale} messages={messages[locale]}>
         <MuiThemeProvider theme={theme}>
           <MuiPickersUtilsProvider
-            libInstance={moment}
-            utils={MomentUtils}
-            locale={locale}
+            utils={DateFnsAdapter}
+            locale={getLocale(locale)}
           >
             <Router>
               <Component {...props} />

--- a/src/dashboard/chartOverview/ChartOverview.tsx
+++ b/src/dashboard/chartOverview/ChartOverview.tsx
@@ -16,7 +16,6 @@ import {
   withStyles,
   WithStyles,
 } from '@material-ui/core/styles';
-import moment from 'moment';
 import DoubleDatePicker from './DoubleDatePicker';
 import CombinedChart from './CombinedChart';
 import ChartCheckboxes from './ChartCheckboxes';
@@ -35,6 +34,7 @@ import {
 import { RootState, RootActions } from '../../utils/store';
 import { ChartTrackingType, ChartFilter } from './chartOverviewUtils';
 import { EXPORT_TOKEN_INVALID } from '../../utils/test-helpers';
+import { addDays } from 'date-fns';
 
 const styles = (theme: Theme): StyleRules => ({
   chartPaper: {
@@ -193,7 +193,7 @@ const mapStateToProps = (state: RootState): StateProps => {
       getActiveChartTrackingTypes(state.chartOverview.filters),
       state.chartOverview.dataSets,
       state.chartOverview.startDate,
-      moment(state.chartOverview.endDate).add(1, 'd').toDate()
+      addDays(state.chartOverview.endDate, 1)
     ),
     symptomsCheckboxes: getSymptomsCheckboxes(state.chartOverview.filters),
     factorsCheckboxes: getFactorsCheckboxes(state.chartOverview.filters),

--- a/src/dashboard/chartOverview/ChartTrackingDatasetCreator.tsx
+++ b/src/dashboard/chartOverview/ChartTrackingDatasetCreator.tsx
@@ -1,12 +1,12 @@
-import moment from 'moment';
 import {
   ChartTrackingTypes,
   chartTypeForChartTrackingType,
 } from './chartOverviewUtils';
 import { TrackingDataPoint, TrackingType, TrackingTypes } from '../types';
+import { parse, parseISO } from 'date-fns';
 
-function parseDate(string: string) {
-  return moment(string).toDate();
+function parseDate(dateString: string, format: string) {
+  return parse(dateString, format, new Date());
 }
 
 function getDayKey(date: Date) {
@@ -43,18 +43,15 @@ const aggregateTrackingDataPointsByDay = (
 ): { [key: string]: TrackingDataPoint[] } => {
   let trackingDataPointsByDay = {};
   trackingDataPoints.forEach((trackingDataPoint) => {
-    if (
-      trackingDataPointsByDay[
-        getDayKey(parseDate(trackingDataPoint.timestampTracking as string))
-      ] === undefined
-    ) {
-      trackingDataPointsByDay[
-        getDayKey(parseDate(trackingDataPoint.timestampTracking as string))
-      ] = [trackingDataPoint];
+    const date =
+      typeof trackingDataPoint.timestampTracking === 'string'
+        ? parseISO(trackingDataPoint.timestampTracking)
+        : trackingDataPoint.timestampTracking;
+
+    if (trackingDataPointsByDay[getDayKey(date)] === undefined) {
+      trackingDataPointsByDay[getDayKey(date)] = [trackingDataPoint];
     } else {
-      trackingDataPointsByDay[
-        getDayKey(parseDate(trackingDataPoint.timestampTracking as string))
-      ].push(trackingDataPoint);
+      trackingDataPointsByDay[getDayKey(date)].push(trackingDataPoint);
     }
   });
   return trackingDataPointsByDay;
@@ -106,7 +103,7 @@ const createSymptomScoreDataset = (symptomScoresPerDay: {
   // Compute value per day depending on type
   let dataSetPoints = Object.keys(symptomScoresPerDay).map(function (day) {
     return {
-      x: moment(day, 'YYYY-MM-DD').toDate(),
+      x: parseDate(day, 'yyyy-MM-dd'),
       y: symptomScoresPerDay[day],
     };
   });
@@ -216,7 +213,7 @@ const createDataSet = (
     }
 
     return {
-      x: moment(day, 'YYYY-MM-DD').toDate(),
+      x: parseDate(day, 'yyyy-MM-dd'),
       y: value,
       tag: tag,
     };

--- a/src/dashboard/chartOverview/CombinedChart.tsx
+++ b/src/dashboard/chartOverview/CombinedChart.tsx
@@ -3,8 +3,8 @@ import { Bar } from 'react-chartjs-2';
 import { ChartOptions } from 'chart.js';
 import { useIntl } from 'react-intl';
 import { makeStyles, useTheme } from '@material-ui/core/styles';
-import moment from 'moment';
 import { ChartTrackingTypes, DataSet } from './chartOverviewUtils';
+import { addDays, subDays } from 'date-fns';
 
 interface OwnProps {
   displayGrids: boolean;
@@ -92,8 +92,8 @@ const CombinedChart: React.FC<Props> = ({
             unit: 'day',
           },
           ticks: {
-            min: moment(startDate).add(-1, 'days').toDate(),
-            max: moment(endDate).add(1, 'days').toDate(),
+            min: subDays(startDate, 1),
+            max: addDays(endDate, 1),
             fontColor: labelsColor,
           },
           scaleLabel: {

--- a/src/dashboard/chartOverview/DoubleDatePicker.tsx
+++ b/src/dashboard/chartOverview/DoubleDatePicker.tsx
@@ -32,13 +32,13 @@ type Props = OwnProps & WrappedComponentProps & WithStyles<typeof styles>;
 class DoubleDatePicker extends React.PureComponent<Props> {
   handleChangeStartDate = (date: MaterialUiPickersDate) => {
     if (date) {
-      this.props.updateStartDate(date.toDate());
+      this.props.updateStartDate(date);
     }
   };
 
   handleChangeEndDate = (date: MaterialUiPickersDate) => {
     if (date) {
-      this.props.updateEndDate(date.toDate());
+      this.props.updateEndDate(date);
     }
   };
 
@@ -53,7 +53,7 @@ class DoubleDatePicker extends React.PureComponent<Props> {
           onChange={this.handleChangeStartDate}
           style={{ width: '95px' }}
           autoOk={true}
-          format="L"
+          format="MM/dd/yyyy"
           maxDate={this.props.endDate}
           label={intl.formatMessage({
             id: 'overview.timePicker.startDate',
@@ -67,7 +67,7 @@ class DoubleDatePicker extends React.PureComponent<Props> {
           onChange={this.handleChangeEndDate}
           style={{ width: '95px' }}
           autoOk={true}
-          format="L"
+          format="MM/dd/yyyy"
           label={intl.formatMessage({
             id: 'overview.timePicker.endDate',
           })}

--- a/src/dashboard/chartOverview/redux/chartSagas.ts
+++ b/src/dashboard/chartOverview/redux/chartSagas.ts
@@ -1,5 +1,4 @@
 import { takeLatest, select, put, call } from 'redux-saga/effects';
-import moment from 'moment';
 import { getTimeFrame, getChartDataPage } from './chartOverview';
 import {
   ChartOverviewActionTypes,
@@ -13,6 +12,7 @@ import {
 import { getPatientId } from '../../../auth';
 import { getTrackingDataPoints } from '../../../utils/api';
 import { RootActions } from '../../../utils/store';
+import { format } from 'date-fns';
 
 const shouldFetchTrackingDataPage = (action: RootActions) =>
   action.type === ChartOverviewActionTypes.FETCH_CHART_DATA_INIT ||
@@ -43,8 +43,8 @@ export function* fetchChartDataPageSaga() {
   const userId = yield select(getPatientId);
   const { startDate, endDate } = yield select(getTimeFrame);
   const currentPage = yield select(getChartDataPage);
-  const start = moment(startDate).format().substring(0, 10);
-  const end = moment(endDate).format().substring(0, 10);
+  const start = format(startDate, 'yyyy-MM-dd');
+  const end = format(endDate, 'yyyy-MM-dd');
   const limit = 100;
   const offset = currentPage * limit;
 

--- a/src/dashboard/trackingOverview/TrackingOverview.tsx
+++ b/src/dashboard/trackingOverview/TrackingOverview.tsx
@@ -15,8 +15,8 @@ import { setDate as setDateAction } from './redux/trackingOverviewActions';
 import { getTrackingDataPointsByTimeDescendingSorted } from './redux/trackingOverviewSelectors';
 import Spinner from '../../components/Spinner';
 import { TrackingDataPoint } from '../types';
-import { addDays } from '../../utils/dateUtils';
 import { RootState, RootActions } from '../../utils/store';
+import { subDays, addDays } from 'date-fns';
 
 const styles = (): StyleRules => ({
   placeholderRow: {
@@ -68,7 +68,7 @@ const TrackingOverview: React.FC<Props> = ({
   setDate,
 }) => {
   const showPreviousDay = () => {
-    setDate(addDays(date, -1));
+    setDate(subDays(date, 1));
   };
 
   const showNextDay = () => {

--- a/src/dashboard/trackingOverview/components/TrackingOverviewHeader.tsx
+++ b/src/dashboard/trackingOverview/components/TrackingOverviewHeader.tsx
@@ -45,7 +45,7 @@ const TrackingOverviewHeader: React.FC<Props> = ({
   const onChangeDate = useCallback(
     (date: MaterialUiPickersDate) => {
       if (date) {
-        updateDate(date.toDate());
+        updateDate(date);
       }
     },
     [updateDate]
@@ -61,7 +61,7 @@ const TrackingOverviewHeader: React.FC<Props> = ({
       <DatePicker
         style={{ width: '85px' }}
         onChange={onChangeDate}
-        format="L"
+        format="MM/dd/yyyy"
         data-testid={TRACKING_OVERVIEW_DATEPICKER}
         autoOk={true}
         value={currentDate}

--- a/src/dashboard/trackingOverview/redux/trackingOverviewSagas.ts
+++ b/src/dashboard/trackingOverview/redux/trackingOverviewSagas.ts
@@ -1,5 +1,4 @@
 import { takeLatest, select, put, call } from 'redux-saga/effects';
-import moment from 'moment';
 import {
   fetchTrackingDataInit,
   fetchTrackingDataFailed,
@@ -16,6 +15,7 @@ import {
 import { getPatientId } from '../../../auth';
 import { getTrackingDataPoints } from '../../../utils/api';
 import { RootActions } from '../../../utils/store';
+import { format } from 'date-fns';
 
 const shouldFetchTrackingDataPage = (action: RootActions) =>
   action.type === TrackingOverviewActionTypes.FETCH_TRACKING_DATA_INIT ||
@@ -45,7 +45,7 @@ export function* fetchTrackingDataPageSaga() {
   const userId = yield select(getPatientId);
   const date = yield select(getTrackingOverviewDate);
   const currentPage = yield select(getTrackingOverviewPage);
-  const start = moment(date).format().substr(0, 10);
+  const start = format(date, 'yyyy-MM-dd');
   const limit = 100;
   const offset = currentPage * limit;
 

--- a/src/programs/pages/Programs.tsx
+++ b/src/programs/pages/Programs.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { useSelector } from 'react-redux';
-import { FormattedMessage } from 'react-intl';
+import { FormattedMessage, useIntl } from 'react-intl';
 import Container from '@material-ui/core/Container';
 import Grid from '@material-ui/core/Grid';
 import Card from '@material-ui/core/Card';
@@ -9,9 +9,9 @@ import CardMedia from '@material-ui/core/CardMedia';
 import Typography from '@material-ui/core/Typography';
 import { Warning } from '@material-ui/icons';
 import { makeStyles } from '@material-ui/core/styles';
-import moment from 'moment';
 import { getPatientTimezone, getPatientEnrolledPrograms } from '../../auth';
 import NutriNavigation from '../../components/NutriNavigation';
+import { formatDate } from '../../utils/dateUtils';
 
 const useStyles = makeStyles((theme) => ({
   container: {
@@ -32,6 +32,7 @@ const Programs = () => {
   const classes = useStyles();
   const timezone = useSelector(getPatientTimezone);
   const programs = useSelector(getPatientEnrolledPrograms);
+  const { locale } = useIntl();
 
   return (
     <>
@@ -52,7 +53,7 @@ const Programs = () => {
                         id="programs.programStarted"
                         defaultMessage="Program started: {date}"
                         values={{
-                          date: moment(program.started).format('LLL'),
+                          date: formatDate(program.started, 'LLL', locale),
                           timezone,
                         }}
                       />

--- a/src/questionnaires/components/Field.tsx
+++ b/src/questionnaires/components/Field.tsx
@@ -3,8 +3,9 @@ import Typography from '@material-ui/core/Typography';
 import { makeStyles } from '@material-ui/core/styles';
 import { v1 } from 'uuid';
 import GetApp from '@material-ui/icons/GetApp';
-import moment from 'moment';
 import { getHost } from '../../utils/constants';
+import { formatDate } from '../../utils/dateUtils';
+import { useIntl } from 'react-intl';
 
 export enum FieldTypes {
   char = 'char',
@@ -40,6 +41,7 @@ const useStyles = makeStyles((theme) => ({
 
 const Field: React.FC<Props> = ({ type, value }) => {
   const classes = useStyles();
+  const { locale } = useIntl();
 
   switch (type) {
     case FieldTypes.char:
@@ -76,7 +78,7 @@ const Field: React.FC<Props> = ({ type, value }) => {
     case FieldTypes.date:
       return (
         <Typography variant="body2">
-          {value ? moment(value).format('L') : '-'}
+          {value ? formatDate(value, 'P', locale) : '-'}
         </Typography>
       );
     case FieldTypes.file:

--- a/src/questionnaires/pages/Questionnaire.tsx
+++ b/src/questionnaires/pages/Questionnaire.tsx
@@ -7,8 +7,7 @@ import { Typography } from '@material-ui/core';
 import ArrowBack from '@material-ui/icons/ArrowBack';
 import { useParams } from 'react-router-dom';
 import { v1 } from 'uuid';
-import moment from 'moment';
-import { FormattedMessage } from 'react-intl';
+import { FormattedMessage, useIntl } from 'react-intl';
 import NutriNavigation from '../../components/NutriNavigation';
 import ErrorMessage from '../components/ErrorMessage';
 import Placeholder from '../../components/Placeholder';
@@ -18,6 +17,7 @@ import Link from '../../components/Link';
 import { getPatientId } from '../../auth';
 import { getQuestionnaire } from '../../utils/api';
 import { QUESTIONNAIRE_NAME } from '../../utils/test-helpers';
+import { formatDate } from '../../utils/dateUtils';
 
 const useStyles = makeStyles((theme) => ({
   container: {
@@ -97,6 +97,7 @@ function reducer(state: QuestionnaireState, action: SumbissionAction) {
 }
 
 const Questionnaire = () => {
+  const { locale } = useIntl();
   const [state, dispatch] = useReducer(reducer, initialState);
   const patientId = useSelector(getPatientId);
   const { id } = useParams();
@@ -162,7 +163,11 @@ const Questionnaire = () => {
                   id="questionnaires.started"
                   defaultMessage="Started: {date}"
                   values={{
-                    date: moment(state.started).format('LLL'),
+                    date: formatDate(
+                      state.started ?? new Date(),
+                      'LLL',
+                      locale
+                    ),
                   }}
                 />
               </Typography>
@@ -171,7 +176,11 @@ const Questionnaire = () => {
                   id="questionnaires.completed"
                   defaultMessage="Completed: {date}"
                   values={{
-                    date: moment(state.completed).format('LLL'),
+                    date: formatDate(
+                      state.completed ?? new Date(),
+                      'LLL',
+                      locale
+                    ),
                   }}
                 />
               </Typography>

--- a/src/questionnaires/pages/Questionnaires.tsx
+++ b/src/questionnaires/pages/Questionnaires.tsx
@@ -1,21 +1,21 @@
-import React, { useState, useEffect } from 'react';
-import { useSelector, useDispatch } from 'react-redux';
-import { FormattedMessage } from 'react-intl';
-import { Link, useRouteMatch } from 'react-router-dom';
-import { makeStyles } from '@material-ui/core/styles';
-import Typography from '@material-ui/core/Typography';
 import Container from '@material-ui/core/Container';
 import Grid from '@material-ui/core/Grid';
 import Paper from '@material-ui/core/Paper';
-import moment from 'moment';
-import NutriNavigation from '../../components/NutriNavigation';
-import Placeholder from '../../components/Placeholder';
-import ErrorMessage from '../components/ErrorMessage';
-import Pagination from '../../components/Pagination';
+import { makeStyles } from '@material-ui/core/styles';
+import Typography from '@material-ui/core/Typography';
+import React, { useEffect, useState } from 'react';
+import { FormattedMessage, useIntl } from 'react-intl';
+import { useDispatch, useSelector } from 'react-redux';
+import { Link, useRouteMatch } from 'react-router-dom';
 import NoResults from '../../components/NoResults';
-import { fetchSubmissionsPageInit } from '../questionnairesActions';
-import { Submission, getSubmissions } from '../questionnairesReducer';
+import NutriNavigation from '../../components/NutriNavigation';
+import Pagination from '../../components/Pagination';
+import Placeholder from '../../components/Placeholder';
+import { formatDate } from '../../utils/dateUtils';
 import { RootState } from '../../utils/store';
+import ErrorMessage from '../components/ErrorMessage';
+import { fetchSubmissionsPageInit } from '../questionnairesActions';
+import { getSubmissions, Submission } from '../questionnairesReducer';
 
 const useStyles = makeStyles((theme) => ({
   container: {
@@ -41,6 +41,7 @@ const useStyles = makeStyles((theme) => ({
 }));
 
 const Questionnaires = () => {
+  const { locale } = useIntl();
   const classes = useStyles();
   const [page, setPage] = useState(0);
   const match = useRouteMatch();
@@ -98,7 +99,11 @@ const Questionnaires = () => {
                             id="questionnaires.started"
                             defaultMessage="Started: {date}"
                             values={{
-                              date: moment(submission.started).format('LLL'),
+                              date: formatDate(
+                                submission.started,
+                                'LLL',
+                                locale
+                              ),
                             }}
                           />
                         </Typography>
@@ -107,7 +112,11 @@ const Questionnaires = () => {
                             id="questionnaires.completed"
                             defaultMessage="Completed: {date}"
                             values={{
-                              date: moment(submission.completed).format('LLL'),
+                              date: formatDate(
+                                submission.completed,
+                                'LLL',
+                                locale
+                              ),
                             }}
                           />
                         </Typography>

--- a/src/utils/dateUtils.ts
+++ b/src/utils/dateUtils.ts
@@ -1,15 +1,61 @@
-import moment from 'moment';
+import { addDays, format as formatDateImpl, parseISO, format } from 'date-fns';
+import { enUS, de } from 'date-fns/locale';
 
 export const newDate = (days: number, referenceDate: Date = new Date()) => {
-  const day = moment(referenceDate).add(days, 'd').toDate();
+  const day = addDays(referenceDate, days);
   day.setHours(0, 0, 0, 0);
   return day;
 };
 
-export const addDays = (date: Date, days: number = 1) => {
-  return moment(date).add(days, 'd').toDate();
-};
+export function getTime(date: Date): string;
+export function getTime(isoString: string): string;
+export function getTime(dateOrIsoString: Date | string): string;
+export function getTime(dateOrIsoString: Date | string) {
+  return format(getDate(dateOrIsoString), 'h:mm a');
+}
 
-export const getTime = (date: Date | string) => {
-  return moment(date).format('h:mm A');
+export function formatDate(
+  isoString: string,
+  format: string,
+  locale: string
+): string;
+export function formatDate(date: Date, format: string, locale: string): string;
+export function formatDate(
+  dateOrIsoString: Date | string,
+  format: string,
+  locale: string
+) {
+  return formatDateImpl(getDate(dateOrIsoString), getFormat(format), {
+    locale: getLocale(locale),
+  });
+}
+
+export function getLocale(localeCode: string) {
+  return localeCode === 'de' ? de : enUS;
+}
+
+export function isSameOrAfter(left: Date, right: Date) {
+  return left.valueOf() >= right.valueOf();
+}
+
+export function isSameOrBefore(left: Date, right: Date) {
+  return left.valueOf() <= right.valueOf();
+}
+
+function getDate(dateOrIsoString: Date | string) {
+  return typeof dateOrIsoString === 'string'
+    ? parseISO(dateOrIsoString)
+    : dateOrIsoString;
+}
+
+function getFormat(formatOrPreset: string) {
+  return presets[formatOrPreset] ?? formatOrPreset;
+}
+
+/**
+ * Only include formats that are _**invalid**_ `date-fns` formats, as to not disallow usages of `getFormat` with a built-in, valid format.
+ */
+const presets = {
+  // LLL is not a valid date-fns format, so it should be fine to use here
+  LLL: 'MMMM d yyyy p',
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -1728,13 +1728,13 @@
 
 "@date-io/core@1.x", "@date-io/core@^1.3.13":
   version "1.3.13"
-  resolved "https://registry.yarnpkg.com/@date-io/core/-/core-1.3.13.tgz#90c71da493f20204b7a972929cc5c482d078b3fa"
+  resolved "https://registry.npmjs.org/@date-io/core/-/core-1.3.13.tgz#90c71da493f20204b7a972929cc5c482d078b3fa"
   integrity sha512-AlEKV7TxjeK+jxWVKcCFrfYAk8spX9aCyiToFIiLPtfQbsjmRGLIhb5VZgptQcJdHtLXo7+m0DuurwFgUToQuA==
 
-"@date-io/moment@^1.3.13":
+"@date-io/date-fns@^1.3.13":
   version "1.3.13"
-  resolved "https://registry.yarnpkg.com/@date-io/moment/-/moment-1.3.13.tgz#56c2772bc4f6675fc6970257e6033e7a7c2960f0"
-  integrity sha512-3kJYusJtQuOIxq6byZlzAHoW/18iExJer9qfRF5DyyzdAk074seTuJfdofjz4RFfTd/Idk8WylOQpWtERqvFuQ==
+  resolved "https://registry.npmjs.org/@date-io/date-fns/-/date-fns-1.3.13.tgz#7798844041640ab393f7e21a7769a65d672f4735"
+  integrity sha512-yXxGzcRUPcogiMj58wVgFjc9qUYrCnnU9eLcyNbsQCmae4jPuZCDoIBR21j8ZURsM7GRtU62VOw5yNd4dDHunA==
   dependencies:
     "@date-io/core" "^1.3.13"
 
@@ -5010,6 +5010,11 @@ date-fns@^1.27.2:
   version "1.30.1"
   resolved "https://registry.yarnpkg.com/date-fns/-/date-fns-1.30.1.tgz#2e71bf0b119153dbb4cc4e88d9ea5acfb50dc05c"
   integrity sha512-hBSVCvSmWC+QypYObzwGOd9wqdDpOt+0wl0KbU+R+uuZBS1jN8VsD1ss3irQDknRj5NvxiTF6oj/nDRnN/UQNw==
+
+date-fns@^2.16.1:
+  version "2.16.1"
+  resolved "https://registry.npmjs.org/date-fns/-/date-fns-2.16.1.tgz#05775792c3f3331da812af253e1a935851d3834b"
+  integrity sha512-sAJVKx/FqrLYHAQeN7VpJrPhagZc9R4ImZIWYRFZaaohR3KzmuK88touwsSwSVT8Qcbd4zoDsnGfX4GFB4imyQ==
 
 date-now@^0.1.4:
   version "0.1.4"
@@ -9059,7 +9064,7 @@ mkdirp@^0.5.4:
   dependencies:
     minimist "^1.2.5"
 
-moment@2.24.0, moment@^2.10.2, moment@^2.22.2:
+moment@2.24.0, moment@^2.10.2:
   version "2.24.0"
   resolved "https://registry.yarnpkg.com/moment/-/moment-2.24.0.tgz#0d055d53f5052aa653c9f6eb68bb5d12bf5c2b5b"
   integrity sha512-bV7f+6l2QigeBBZSM/6yTNq4P2fNpSWj/0e7jQcy87A8e7o2nAfP/34/2ky5Vw4B9S446EtIhodAzkFCcR4dQg==


### PR DESCRIPTION
## Description
Moment.js has recently [entered maintenance mode](https://momentjs.com/docs/#/-project-status/), and replacing it in this project has been a long-ish standing issue (#10). This PR aims to replace `moment` with `date-fns` completely, with everything that's under this project's direct control.

**Does this PR introduces a breaking change?**
No

### Related Issues
Fixes #10.

## Checklist

- [x] Lint and unit tests pass locally with my changes.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] I have added necessary documentation (if appropriate).
