### PR TITLE
Chat improvements (Enter, reconnect)

### DIFF
--- a/src/chat/components/InputToolbar.tsx
+++ b/src/chat/components/InputToolbar.tsx
@@ -50,13 +50,6 @@ export default function InputToolbar({ onSubmit }: InputToolbarProps) {
     setMessage(e.target.value);
   };
 
-  const handleEnterPress = (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
-    if (e.keyCode === 13 && e.shiftKey === false) {
-      e.preventDefault();
-      handleSubmit();
-    }
-  };
-
   const handleSubmit = () => {
     if (message) {
       onSubmit(message);
@@ -70,7 +63,6 @@ export default function InputToolbar({ onSubmit }: InputToolbarProps) {
         <textarea
           value={message}
           onChange={handleChange}
-          onKeyDown={handleEnterPress}
           className={classes.input}
           rows={3}
           data-testid={CHAT_MESSAGE_INPUT}

--- a/src/chat/pages/Inbox.tsx
+++ b/src/chat/pages/Inbox.tsx
@@ -87,7 +87,7 @@ export default function Inbox() {
     } catch (error) {
       console.log(error);
     }
-  }, []);
+  }, [dispatch]);
 
   useEffect(() => {
     if (open) return;
@@ -95,7 +95,7 @@ export default function Inbox() {
       establishSocketConnection();
     }, 5000);
     return () => clearInterval(interval);
-  }, [open]);
+  }, [open, establishSocketConnection]);
 
   useEffect(() => {
     establishSocketConnection();
@@ -104,7 +104,7 @@ export default function Inbox() {
         console.info('The socket was closed');
       });
     };
-  }, [dispatch]);
+  }, [dispatch, establishSocketConnection]);
 
   const [width, setWidth] = React.useState(320);
 

--- a/src/chat/redux/chatReducer.ts
+++ b/src/chat/redux/chatReducer.ts
@@ -99,9 +99,10 @@ export const chatReducer: Reducer<ChatState, ChatActions> = (
         scrollToChatBottom: true,
       };
     case ChatActionTypes.SET_CHAT_MESSAGES:
+      const newChatMessages = uniqBy([...state.chatMessages, ...action.chatMessages], 'id');
       return {
         ...state,
-        chatMessages: [...state.chatMessages, ...action.chatMessages],
+        chatMessages: newChatMessages,
       };
     case ChatActionTypes.CLEAR_CHAT_MESSAGES:
       return {
@@ -115,7 +116,6 @@ export const chatReducer: Reducer<ChatState, ChatActions> = (
         chatRooms: [action.chatRoom, ...state.chatRooms],
       };
     case ChatActionTypes.SET_CHAT_ROOMS:
-      // uniq, becasue of sagas -> (refetching all)
       const newChatRooms = uniqBy(action.chatRooms, 'patient.id');
       return {
         ...state,


### PR DESCRIPTION
- Disabling sending messages by Enter press
- Manually setting reconnection interval when the socket was not open before
- Prevent setting same messages when refetchOnReconnect (react-query) was triggered

## Checklist

- [ ] Lint and unit tests pass locally with my changes.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added necessary documentation (if appropriate).
