### PR TITLE
Fixes

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,7 @@
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+indent_style = space
+indent_size = 4

--- a/.editorconfig
+++ b/.editorconfig
@@ -4,4 +4,4 @@ root = true
 charset = utf-8
 end_of_line = lf
 indent_style = space
-indent_size = 4
+indent_size = 2

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -14,6 +14,7 @@ module.exports = {
     'prettier/prettier': [
       'error',
       {
+        indent: 2,
         singleQuote: true,
         trailingComma: 'es5',
       },

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   "scripts": {
     "cy:open": "cypress open",
     "cy:run": "cypress run",
-    "start": "cross-env HTTPS=true react-scripts start",
+    "start": "cross-env HTTPS=true BROWSER=none react-scripts start",
     "prebuild": "./scripts/deploy.sh",
     "build": "react-scripts build",
     "test": "react-scripts test",

--- a/src/components/withProviders.tsx
+++ b/src/components/withProviders.tsx
@@ -41,7 +41,17 @@ const withProviders = (
 
     return (
       <ReactQueryCacheProvider queryCache={queryCache}>
-        <IntlProvider locale={locale} messages={messages[locale]}>
+        <IntlProvider
+          locale={locale}
+          messages={messages[locale]}
+          onError={(err) => {
+            if (err.code === "MISSING_TRANSLATION") {
+              console.warn("Missing translation", err.message);
+              return;
+            }
+            throw err;
+          }}
+        >
           <MuiThemeProvider theme={theme}>
             <MuiPickersUtilsProvider
               utils={DateFnsAdapter}

--- a/src/components/withProviders.tsx
+++ b/src/components/withProviders.tsx
@@ -45,11 +45,11 @@ const withProviders = (
           locale={locale}
           messages={messages[locale]}
           onError={(err) => {
-            if (err.code === "MISSING_TRANSLATION") {
-              console.warn("Missing translation", err.message);
-              return;
+            if (err.code === 'MISSING_TRANSLATION') {
+              console.warn(err.message);
+            } else {
+              console.error(err);
             }
-            throw err;
           }}
         >
           <MuiThemeProvider theme={theme}>

--- a/src/setupProxy.js
+++ b/src/setupProxy.js
@@ -4,7 +4,7 @@ module.exports = function (app) {
   app.use(
     '/api/**',
     createProxyMiddleware({
-      target: 'https://staging.cara.care',
+      target: 'https://eu-staging.cara.care',
       // ws: true, // <-- broken tests but needed for chat development
       ws: process.env.NODE_ENV === 'production',
       changeOrigin: true,


### PR DESCRIPTION
## Description

- Added `.editorconfig`.
- Fixed the failing `yarn lint` by explicitly setting the indentation to 2 spaces.
- Missing translations now produce warnings instead of errors in the console.
- Disabled the browser auto-open when invoking `yarn start`.
- Updated the URL of the staging backend server.

No breaking changes are introduced.


## Checklist

- [x] Lint and unit tests pass locally with my changes.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added necessary documentation (if appropriate).
