### PR TITLE
Display the letterId from the success response on the success modal

### DIFF
--- a/src/epost/PrescriptionEpostService.tsx
+++ b/src/epost/PrescriptionEpostService.tsx
@@ -370,11 +370,11 @@ const PrescriptionEpostService: React.FC<RouteComponentProps<{
             </Typography>
             <Typography className={styles.subtitle} variant="body1">
               <b>Address: </b>
-              {formData.addressLineOne}, {formData.addressLineTwo},
+              {formData.addressLineOne}, {formData.addressLineTwo},{' '}
               {formData.city}, {formData.postCode}
               <br />
               <b>Sender Address: </b>
-              {formData.senderAddressLineOne}, {formData.senderAddressLineTwo},
+              {formData.senderAddressLineOne}, {formData.senderAddressLineTwo},{' '}
               {formData.senderPostCode}, {formData.senderCity}
               <br />
               <b>PDF file name: </b>


### PR DESCRIPTION
## Description

Displays the letterId we get in the success response to the user so they can make note of it for future reference:
<img width="581" alt="Screenshot 2023-03-28 at 13 00 07" src="https://user-images.githubusercontent.com/23412989/228215722-23a15ea5-255e-4d7a-baaa-8b6313c52255.png">

<img width="791" alt="Screenshot 2023-03-28 at 13 00 16" src="https://user-images.githubusercontent.com/23412989/228215731-0c5ab63e-e2a9-4283-9a12-09c60754ea32.png">

