### PR TITLE
Add error message to dashboard

### DIFF
--- a/src/epost/Track.tsx
+++ b/src/epost/Track.tsx
@@ -46,6 +46,9 @@ const useStyles = makeStyles((theme) => ({
     backgroundColor: '#f1f1f1',
     marginBottom: '20px',
   },
+  warningText: {
+    color: '#FA5544',
+  },
   smallColumn: {
     flex: 1,
   },
@@ -245,7 +248,7 @@ const Track: React.FC<RouteComponentProps<{}>> = () => {
                 <Typography variant="body1">{item.letterReceiver}</Typography>
               </div>
               <div className={styles.column}>
-                <Typography variant="body1">{item.status}</Typography>
+                <Typography variant="body1" className={item.status === 'EPOST_ERROR' ? styles.warningText : undefined}>{item.status}</Typography>
               </div>
               <div className={styles.column}>
                 <Typography variant="body1">
@@ -313,6 +316,13 @@ const Track: React.FC<RouteComponentProps<{}>> = () => {
                   {reviewItem.approved
                     ? new Date(reviewItem.uploaded).toUTCString()
                     : 'Pending approval'}
+                  {reviewItem.errorMessage && (
+                    <>
+                      <br />
+                      <b className={styles.warningText}>Error message: </b>
+                      {reviewItem.errorMessage}
+                    </>
+                  )}
                   <div className={styles.pdfContainer}>
                     <a href={`/api/${reviewItem?.pdfFile}`} download>
                       <p>View PDF</p>

--- a/src/epost/Track.tsx
+++ b/src/epost/Track.tsx
@@ -248,7 +248,16 @@ const Track: React.FC<RouteComponentProps<{}>> = () => {
                 <Typography variant="body1">{item.letterReceiver}</Typography>
               </div>
               <div className={styles.column}>
-                <Typography variant="body1" className={item.status === 'EPOST_ERROR' ? styles.warningText : undefined}>{item.status}</Typography>
+                <Typography
+                  variant="body1"
+                  className={
+                    item.status === 'EPOST_ERROR'
+                      ? styles.warningText
+                      : undefined
+                  }
+                >
+                  {item.status}
+                </Typography>
               </div>
               <div className={styles.column}>
                 <Typography variant="body1">

--- a/src/epost/types.ts
+++ b/src/epost/types.ts
@@ -36,4 +36,5 @@ export interface Prescription {
     id: number;
     name: string;
   };
+  errorMessage: string;
 }


### PR DESCRIPTION
## Description

Adds an error message to the tracking section of the dashboard, which is visible if the user clicks on the entry for more info:

Demo of how it will look: 

![Screenshot 2023-07-31 at 17 22 24](https://github.com/cara-care/dashboard/assets/23412989/cdab432d-74c7-4571-b73f-c944c70a1b5a)
![Screenshot 2023-07-31 at 17 23 05](https://github.com/cara-care/dashboard/assets/23412989/67acd464-caa4-4d80-8198-9f6b97366bb9)

